### PR TITLE
Workflow Keywords First Revision

### DIFF
--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -4,6 +4,8 @@ There are a number of **keywords** with a defined meaning. These are commonly us
 
 ## [**Status-based Keywords**](https://make.wordpress.org/core/handbook/contribute/trac/keywords/#status-based-keywords)
 
+Status keywords are used to track the status of a ticket asynchronously. Most are meant for informational purposes to increase the quality of the ticket, and others are useful for batch processing, for example, when creating a Field Guide entry.
+
 **close**
 
 The ticket is a candidate for closure with a disposition other than fixed (i.e. **wontfix**, **worksforme**, **invalid**, or **duplicate**). Often seen with **reporter-feedback** or **2nd-opinion**; otherwise, the ticket would have been closed in lieu of adding the **close** keyword.
@@ -57,6 +59,8 @@ This keyword signals that the ticket would be a good starting point for new cont
 When paired with the `php-compatibility` focus, this manually added keyword identifies the specific PHP version (i.e. `NN`) that first introduced a compatibility issue or task. For example, `php80` keyword identifies that PHP 8.0 is the version that first introduced the incompatibility.
 
 ## [**Action-based Keywords**](https://make.wordpress.org/core/handbook/contribute/trac/keywords/#action-based-keywords)
+
+Action-based keywords are steps in the workflow that require action from a specific person or group of people. They should never be combined with other action-based keywords at the same time because they reflect the exact step position in the workflow.
 
 **needs-design**
 

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -76,7 +76,7 @@ The ticket has been reviewed, found to be desirable to solve, and marked as espe
 
 **2nd-opinion**
 
-Another person is needed to express an opinion about the problem or the solution.
+An opinion is wanted from a [core developer](https://make.wordpress.org/core/handbook/about/organization/#the-wordpress-core-team) or any other member of the development community about the problem or the solution in the ticket.
 
 **needs-copy-review**
 
@@ -116,7 +116,7 @@ The patch has been reviewed, found to be desirable to be implemented, and we wou
 
 **dev-feedback**
 
-A response is wanted from a [core developer](https://make.wordpress.org/core/handbook/about/organization/#the-wordpress-core-team) or trusted members of the development community. For example, use this keyword when double sign-off is required to [backport changes during RC](https://make.wordpress.org/core/handbook/best-practices/backporting-commits/#backport-process).
+Action is required from a [core developer](https://make.wordpress.org/core/handbook/about/organization/#the-wordpress-core-team). For general feedback about the ticket use the `2nd-opinion` keyword instead. For example, use this keyword when the patch has been code-reviewed and it is ready for commit or when a double sign-off is required to [backport changes during RC](https://make.wordpress.org/core/handbook/best-practices/backporting-commits/#backport-process).
 
 **needs-privacy-review**
 

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -102,6 +102,10 @@ Input is needed from the patch author to provide information about how the patch
 
 Feedback has been provided, and the attached patch needs to be updated.
 
+**needs-code-review**
+
+The patch has been tested, the functionality is working as expected, but needs to be reviewed by a developer to ensure its correctness.
+
 **needs-docs**
 
 Inline documentation for the code is needed. These are either place holder tickets for individual files, or tickets with patches for new functions which need documenting before they are committed.

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -20,6 +20,10 @@ A proposed solution to the ticket has been attached, and it is ready for review.
 
 Serves as a partner to _needs-screenshots_. Once a ticket has at least one screenshot, tag it with has-screenshots. If more screenshots are needed, leave needs-screenshots on the ticket until all screenshots are provided. [#has-screenshots](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=closed&status=new&status=reopened&status=reviewing&keywords=~has-screenshots&col=id&col=summary&col=status&col=owner&col=type&col=priority&col=milestone&col=changetime&order=priority) is used to create visual changelogs and the [Today in the Nightly](https://make.wordpress.org/core/tag/today-in-the-nightly/) posts. Do not clear this tag from closed tickets. has-screenshot and needs-screenshots are part of the post-commit diligence lifecycle and are expected to exist on closed tickets. need-screenshots exists temporarily until all screenshots are provided and has-screenshots exists permanently.
 
+**has-test-info**
+
+Input has been given from the patch author to provide information about how the bug can be reproduced or how the patch can be tested.
+
 **has-unit-tests**
 
 The ticket has been reviewed, found to be desirable to solve, and the latest patch contains unit tests. Like _needs-unit-tests_, this keyword indicates the proposed changes constitute a high risk of causing other issues.
@@ -35,6 +39,10 @@ Input has been given from the [core privacy team](https://make.wordpress.org/cor
 **has-dev-note**
 
 A [dev note](https://make.wordpress.org/core/tag/dev-notes/) has been published on the make core blog outlining this change. This change provides significant new functionality, a large refactor, or includes a breaking change.
+
+**add-to-field-guide**
+
+The ticket `dev-note` is a candidate for addition to the [Field Guide](https://make.wordpress.org/core/handbook/contribute/field-guide/).
 
 **fixed-major**
 
@@ -86,6 +94,10 @@ A submitted patch no longer applies cleanly to the WordPress core files, usually
 
 Patches and commits that change UI need screenshots. Document visual iterations. Upload screenshots directly to the ticket or post to [make/flow](https://make.wordpress.org/flow/) for more involved visual documentation such as visual records or visual surveys. Cross-link any make/flow posts with the ticket. Remove the needs-screenshots keyword from the ticket once screenshots for both a desktop and a phone, at the least, are provided. Full context screenshots taken on physical devices are preferred. New patches require new screenshots. Once a ticket has at least one of the needed screenshots, tag it with has-screenshots. [#needs-screenshots](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=closed&status=new&status=reopened&status=reviewing&keywords=~needs-screenshots&col=id&col=summary&col=status&col=owner&col=type&col=priority&col=milestone&order=priority)
 
+**needs-test-info**
+
+Input is needed from the patch author to provide information about how the patch was tested. Step by step instructions are always preferred, but sometimes a [Testing Use-Case](https://make.wordpress.org/test/2025/05/15/building-the-testing-use-case/) is required.
+
 **changes-requested**
 
 Feedback has been provided, and the attached patch needs to be updated.
@@ -96,7 +108,7 @@ Inline documentation for the code is needed. These are either place holder ticke
 
 **needs-unit-tests**
 
-The ticket has been reviewed, found to be desirable to solve, and we would like some unit tests written to test the functionality and any patch that may exist before committing a change, as the risk of causing other issues is high.
+The patch has been reviewed, found to be desirable to be implemented, and we would like some unit tests written to test the functionality and any patch that may exist before committing a change, as the risk of causing other issues is high.
 
 **dev-feedback**
 
@@ -105,6 +117,10 @@ A response is wanted from a [core developer](https://make.wordpress.org/core/han
 **needs-privacy-review**
 
 Input is needed from the [core privacy team](https://make.wordpress.org/core/components/privacy/) with regards to the privacy implications of the suggested changes.
+
+**needs-user-docs**
+
+The user documentation needs to be updated to updated or expanded.
 
 **needs-dev-note**
 

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -40,7 +40,7 @@ A [dev note](https://make.wordpress.org/core/tag/dev-notes/) has been published 
 
 Only used late in the development cycle (after a branch has been created for a release) to indicate that an issue has been “fixed” in the next “major” version (trunk) and needs to be merged back to the branch for the upcoming release by a permanent committer.  (There is also “fixed-minor” which indicates that an issue needs to be merged back into trunk from a minor release branch; more info about these keywords in this post: [The keywords “fixed-major” and “fixed-minor”](https://make.wordpress.org/core/2011/04/06/the-keywords-fixed-major-and-fixed/).)
 
-**good-first-****bug**
+**good-first-bug**
 
 This keyword signals that the ticket would be a good starting point for new contributors to get used to the process before tackling more complicated tickets.
 
@@ -110,7 +110,7 @@ Input is needed from the [core privacy team](https://make.wordpress.org/core/com
 
 This change is one that warrants a [dev note](https://make.wordpress.org/core/tag/dev-notes/) on the make core blog. If a change is significant new functionality, a large refactor, or includes a breaking change, it always requires a dev note.
 
-**i18n****\-change**
+**i18n-change**
 
 Only used late in the development cycle (after string freeze) to track potential string changes, as translators need to be notified.
 

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -4,21 +4,13 @@ There are a number of **keywords** with a defined meaning. These are commonly us
 
 ## [**Status-based Keywords**](https://make.wordpress.org/core/handbook/contribute/trac/keywords/#status-based-keywords)
 
-**changes-requested**
-
-Feedback has been provided, and the attached patch needs to be updated.
-
 **close**
 
 The ticket is a candidate for closure with a disposition other than fixed (i.e. **wontfix**, **worksforme**, **invalid**, or **duplicate**). Often seen with **reporter-feedback** or **2nd-opinion**; otherwise, the ticket would have been closed in lieu of adding the **close** keyword.
 
-**early**
+**has-copy-review**
 
-This keyword should only be applied by committers. The keyword signals that the ticket is a priority, and should be handled early in the next release cycle.
-
-**good-first-****bug**
-
-This keyword signals that the ticket would be a good starting point for new contributors to get used to the process before tackling more complicated tickets.
+Input has been given from a copywriter reviewing the suggested verbiage changes.
 
 **has-patch**
 
@@ -32,71 +24,31 @@ Serves as a partner to _needs-screenshots_. Once a ticket has at least one scree
 
 The ticket has been reviewed, found to be desirable to solve, and the latest patch contains unit tests. Like _needs-unit-tests_, this keyword indicates the proposed changes constitute a high risk of causing other issues.
 
-**needs-docs**
+**early**
 
-Inline documentation for the code is needed. These are either place holder tickets for individual files, or tickets with patches for new functions which need documenting before they are committed.
+This keyword should only be applied by committers. The keyword signals that the ticket is a priority, and should be handled early in the next release cycle.
 
-**needs-patch**
+**has-privacy-review**
 
-The ticket has been reviewed, found to be desirable to solve, and marked as especially needing a patch, or the submitted patch doesn’t work and needs to be redone.
+Input has been given from the [core privacy team](https://make.wordpress.org/core/components/privacy/) reviewing the privacy implications of the suggested changes.
 
-**needs-refresh**
+**has-dev-note**
 
-A submitted patch no longer applies cleanly to the WordPress core files, usually because nearby code has been modified since the patch was submitted. The patch needs to be merged and re-submitted.
+A [dev note](https://make.wordpress.org/core/tag/dev-notes/) has been published on the make core blog outlining this change. This change provides significant new functionality, a large refactor, or includes a breaking change.
 
-**needs-screenshots**
+**fixed-major**
 
-Patches and commits that change UI need screenshots. Document visual iterations. Upload screenshots directly to the ticket or post to [make/flow](https://make.wordpress.org/flow/) for more involved visual documentation such as visual records or visual surveys. Cross-link any make/flow posts with the ticket. Remove the needs-screenshots keyword from the ticket once screenshots for both a desktop and a phone, at the least, are provided. Full context screenshots taken on physical devices are preferred. New patches require new screenshots. Once a ticket has at least one of the needed screenshots, tag it with has-screenshots. [#needs-screenshots](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=closed&status=new&status=reopened&status=reviewing&keywords=~needs-screenshots&col=id&col=summary&col=status&col=owner&col=type&col=priority&col=milestone&order=priority)
+Only used late in the development cycle (after a branch has been created for a release) to indicate that an issue has been “fixed” in the next “major” version (trunk) and needs to be merged back to the branch for the upcoming release by a permanent committer.  (There is also “fixed-minor” which indicates that an issue needs to be merged back into trunk from a minor release branch; more info about these keywords in this post: [The keywords “fixed-major” and “fixed-minor”](https://make.wordpress.org/core/2011/04/06/the-keywords-fixed-major-and-fixed/).)
 
-**needs-unit-tests**
+**good-first-****bug**
 
-The ticket has been reviewed, found to be desirable to solve, and we would like some unit tests written to test the functionality and any patch that may exist before committing a change, as the risk of causing other issues is high.
+This keyword signals that the ticket would be a good starting point for new contributors to get used to the process before tackling more complicated tickets.
 
 **phpNN**
 
 When paired with the `php-compatibility` focus, this manually added keyword identifies the specific PHP version (i.e. `NN`) that first introduced a compatibility issue or task. For example, `php80` keyword identifies that PHP 8.0 is the version that first introduced the incompatibility.
 
 ## [**Action-based Keywords**](https://make.wordpress.org/core/handbook/contribute/trac/keywords/#action-based-keywords)
-
-**2nd-opinion**
-
-Another person is needed to express an opinion about the problem or the solution.
-
-**commit**
-
-The patch has been reviewed and tested by a trusted member of the development community; therefore, the patch should be considered a commit candidate, and is ready to be added to the WordPress core files.
-
-**dev-feedback**
-
-A response is wanted from a [core developer](https://make.wordpress.org/core/handbook/about/organization/#the-wordpress-core-team) or trusted members of the development community. For example, use this keyword when double sign-off is required to [backport changes during RC](https://make.wordpress.org/core/handbook/best-practices/backporting-commits/#backport-process).
-
-**dev-reviewed**
-
-After a branch has been created for a release, each change (except for build and test suite changes) needs to be reviewed by two permanent committers. The first reviewer should set the keywords “commit dev-feedback”, and the second reviewer should set the keywords “commit dev-reviewed”. If a permanent committer created the patch, only one additional review is necessary.
-
-**fixed-major**
-
-Only used late in the development cycle (after a branch has been created for a release) to indicate that an issue has been “fixed” in the next “major” version (trunk) and needs to be merged back to the branch for the upcoming release by a permanent committer.  (There is also “fixed-minor” which indicates that an issue needs to be merged back into trunk from a minor release branch; more info about these keywords in this post: [The keywords “fixed-major” and “fixed-minor”](https://make.wordpress.org/core/2011/04/06/the-keywords-fixed-major-and-fixed/).)
-
-**has-copy-review**
-
-Input has been given from a copywriter reviewing the suggested verbiage changes.
-
-**has-dev-note**
-
-A [dev note](https://make.wordpress.org/core/tag/dev-notes/) has been published on the make core blog outlining this change. This change provides significant new functionality, a large refactor, or includes a breaking change.
-
-**has-privacy-review**
-
-Input has been given from the [core privacy team](https://make.wordpress.org/core/components/privacy/) reviewing the privacy implications of the suggested changes.
-
-**i18n****\-change**
-
-Only used late in the development cycle (after string freeze) to track potential string changes, as translators need to be notified.
-
-**needs-copy-review**
-
-Input is needed from a copywriter with regards to the suggested verbiage changes.
 
 **needs-design**
 
@@ -106,18 +58,67 @@ A designer should create a prototype of how the suggested changes should look/be
 
 A designer should review and give feedback on the proposed changes.
 
-**needs-dev-note**
+**reporter-feedback**
 
-This change is one that warrants a [dev note](https://make.wordpress.org/core/tag/dev-notes/) on the make core blog. If a change is significant new functionality, a large refactor, or includes a breaking change, it always requires a dev note.
+A response is needed from the reporter. Further investigation is unlikely without a response to the questions from someone experiencing the problem.
 
-**needs-privacy-review**
+**needs-patch**
 
-Input is needed from the [core privacy team](https://make.wordpress.org/core/components/privacy/) with regards to the privacy implications of the suggested changes.
+The ticket has been reviewed, found to be desirable to solve, and marked as especially needing a patch, or the submitted patch doesn’t work and needs to be redone.
+
+**2nd-opinion**
+
+Another person is needed to express an opinion about the problem or the solution.
+
+**needs-copy-review**
+
+Input is needed from a copywriter with regards to the suggested verbiage changes.
 
 **needs-testing**
 
 One or more people are needed to test the solution. When testing a patch, please comment with the patch filename that was tested, how the patch was tested, and which version of WordPress was used (including the SVN revision number, if it is not an officially released version).
 
-**reporter-feedback**
+**needs-refresh**
 
-A response is needed from the reporter. Further investigation is unlikely without a response to the questions from someone experiencing the problem.
+A submitted patch no longer applies cleanly to the WordPress core files, usually because nearby code has been modified since the patch was submitted. The patch needs to be merged and re-submitted.
+
+**needs-screenshots**
+
+Patches and commits that change UI need screenshots. Document visual iterations. Upload screenshots directly to the ticket or post to [make/flow](https://make.wordpress.org/flow/) for more involved visual documentation such as visual records or visual surveys. Cross-link any make/flow posts with the ticket. Remove the needs-screenshots keyword from the ticket once screenshots for both a desktop and a phone, at the least, are provided. Full context screenshots taken on physical devices are preferred. New patches require new screenshots. Once a ticket has at least one of the needed screenshots, tag it with has-screenshots. [#needs-screenshots](https://core.trac.wordpress.org/query?status=accepted&status=assigned&status=closed&status=new&status=reopened&status=reviewing&keywords=~needs-screenshots&col=id&col=summary&col=status&col=owner&col=type&col=priority&col=milestone&order=priority)
+
+**changes-requested**
+
+Feedback has been provided, and the attached patch needs to be updated.
+
+**needs-docs**
+
+Inline documentation for the code is needed. These are either place holder tickets for individual files, or tickets with patches for new functions which need documenting before they are committed.
+
+**needs-unit-tests**
+
+The ticket has been reviewed, found to be desirable to solve, and we would like some unit tests written to test the functionality and any patch that may exist before committing a change, as the risk of causing other issues is high.
+
+**dev-feedback**
+
+A response is wanted from a [core developer](https://make.wordpress.org/core/handbook/about/organization/#the-wordpress-core-team) or trusted members of the development community. For example, use this keyword when double sign-off is required to [backport changes during RC](https://make.wordpress.org/core/handbook/best-practices/backporting-commits/#backport-process).
+
+**needs-privacy-review**
+
+Input is needed from the [core privacy team](https://make.wordpress.org/core/components/privacy/) with regards to the privacy implications of the suggested changes.
+
+**needs-dev-note**
+
+This change is one that warrants a [dev note](https://make.wordpress.org/core/tag/dev-notes/) on the make core blog. If a change is significant new functionality, a large refactor, or includes a breaking change, it always requires a dev note.
+
+**i18n****\-change**
+
+Only used late in the development cycle (after string freeze) to track potential string changes, as translators need to be notified.
+
+**commit**
+
+The patch has been reviewed and tested by a trusted member of the development community; therefore, the patch should be considered a commit candidate, and is ready to be added to the WordPress core files.
+
+**dev-reviewed**
+
+After a branch has been created for a release, each change (except for build and test suite changes) needs to be reviewed by two permanent committers. The first reviewer should set the keywords “commit dev-feedback”, and the second reviewer should set the keywords “commit dev-reviewed”. If a permanent committer created the patch, only one additional review is necessary.
+

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -32,10 +32,6 @@ Serves as a partner to _needs-screenshots_. Once a ticket has at least one scree
 
 The ticket has been reviewed, found to be desirable to solve, and the latest patch contains unit tests. Like _needs-unit-tests_, this keyword indicates the proposed changes constitute a high risk of causing other issues.
 
-**needs-codex**
-
-Documentation in the Codex needs updating or expanding. Remove the keyword from the ticket once the Codex is updated.
-
 **needs-docs**
 
 Inline documentation for the code is needed. These are either place holder tickets for individual files, or tickets with patches for new functions which need documenting before they are committed.

--- a/trac-workflow-keywords.md
+++ b/trac-workflow-keywords.md
@@ -8,7 +8,7 @@ Status keywords are used to track the status of a ticket asynchronously. Most ar
 
 **close**
 
-The ticket is a candidate for closure with a disposition other than fixed (i.e. **wontfix**, **worksforme**, **invalid**, or **duplicate**). Often seen with **reporter-feedback** or **2nd-opinion**; otherwise, the ticket would have been closed in lieu of adding the **close** keyword.
+The ticket is a candidate for closure with a disposition other than fixed (i.e. **wontfix**, **worksforme**, **invalid**, or **duplicate**), while allowing a bit more time for additional details or opinions to be offered. Often seen with **reporter-feedback** or **2nd-opinion**; otherwise, the ticket would have been closed in lieu of adding the **close** keyword.
 
 **has-copy-review**
 


### PR DESCRIPTION
This is the first revision for the Keywords Workflow.

I've divided into commits the different changes.

1. `need-codex` keyword is no longer being used, so it must removed
2. According to the schematics that I will be providing soon for those who are willing to review this changes, I've ordered based on the sequence in time
3. Added all the missing keywowrds that are being used nowadays:  needs-test-info, 
needs-code-review, needs-user-docs, has-test-info, and add-to-field-guide
4. Added my new KW proposal: [More info](https://test.wp.voz.cat/share/7cmna0gaq3/p/the-code-review-workflow-flaw-x2xEBPdhrU). Check 4th June 25 `dev-chat` for more info.
5. Modified `2nd-opinion` and `dev-feedback` to better match the workflow accordingly and disambiguate them.